### PR TITLE
Implement basic operations in Haskell 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Stack is a Haskell build tool, which allows for cross-platform, reproducible bui
 The build toolchain of this project depends on `stack`, so please follow the installation
 instructions as [outlined here](http://docs.haskellstack.org/en/stable/README/#how-to-install)
 
-### [SymEngine](), the library that this package provides a Haskell interface for
+### SymEngine, the library that this package provides a Haskell interface for
 
 Please go through the `SymEngine` installation instructions, and make sure that the header files
 as well as the libraries

--- a/README.md
+++ b/README.md
@@ -31,20 +31,42 @@ Since these are *hard* dependencies for SymEngine-hs to build.
 To quickly build and check everything is working, run
 
 ```
-stack build && stack exec symengine-hs-exe
+stack build && stack test
 ```
 
-You should see
+All of the test cases should pass with SymEngine
+
+## Playing around in the interpreter
+
+to launch a `GHCi` session, execute the interpreter with
 
 ```
- _____           _____         _
-|   __|_ _ _____|   __|___ ___|_|___ ___
-|__   | | |     |   __|   | . | |   | -_|
-|_____|_  |_|_|_|_____|_|_|_  |_|_|_|___|
-      |___|               |___|
+stack ghci --ghci-options " -lstdc++ -lgmpxx -lgmp -lsymengine -L/usr/local/lib/"
 ```
 
-As the output.
+
+Make sure that you have built `symengine.so` (NOTE: you __need_ the shared object, and not just the library), and
+have installed the shared object as well.
+
+
+Once you are inside `GHCi`, you can execute basic functions such as `basic_const_zero`, `basic_const_one`, etc.
+
+
+A typical  interpreter session will look like this:
+
+```
+GHCi session with Symengine loaded
+---
+
+*Symengine Symengine> basic_const_zero
+0
+*Symengine Symengine> basic_const_zero
+0
+*Symengine Symengine> basic_const_one
+1
+*Symengine Symengine> basic_const_minus_one
+-1
+```
 
 # Things to Do
 

--- a/src/Symengine.hs
+++ b/src/Symengine.hs
@@ -5,6 +5,8 @@ module Symengine
      ascii_art_str,
      basic_str,
      basic_const_zero,
+     basic_const_one,
+     basic_const_minus_one,
      BasicPtr,
     ) where
 
@@ -35,34 +37,52 @@ instance Show BasicPtr where
 
 
 basic_const_zero :: IO BasicPtr
-basic_const_zero = do
+basic_const_zero = basic_obj_constructor basic_const_zero_ffi
+
+
+basic_const_one :: IO BasicPtr
+basic_const_one = basic_obj_constructor basic_const_one_ffi
+
+basic_const_minus_one :: IO BasicPtr
+basic_const_minus_one = basic_obj_constructor basic_const_minus_one_ffi
+
+basic_const_I :: IO BasicPtr
+basic_const_I = basic_obj_constructor basic_const_I_ffi
+
+
+basic_obj_constructor :: (Ptr BasicStruct -> IO ()) -> IO BasicPtr
+basic_obj_constructor init_fn = do
     basic_ptr <- create_basic_ptr
-    withForeignPtr (fptr basic_ptr) basic_const_zero_raw
+    withForeignPtr (fptr basic_ptr) init_fn
     return $ basic_ptr
 
 basic_str :: BasicPtr -> String
-basic_str basic_ptr = unsafePerformIO $ withForeignPtr (fptr basic_ptr) (\p -> basic_str_raw p >>= peekCString)
+basic_str basic_ptr = unsafePerformIO $ withForeignPtr (fptr basic_ptr) (\p -> basic_str_ffi p >>= peekCString)
 
 -- |The `ascii_art_str` function prints SymEngine in ASCII art.
 -- this is useful as a sanity check
 ascii_art_str :: IO String
-ascii_art_str = ascii_art_str_raw >>= peekCString
+ascii_art_str = ascii_art_str_ffi >>= peekCString
 
--- Unexported raw functions------------------------
+-- Unexported ffi functions------------------------
 
 -- |Create a basic object that represents all other objects through
 -- the FFI
 create_basic_ptr :: IO BasicPtr
 create_basic_ptr = do
     basic_ptr <- newArray [BasicStruct { data_ptr = nullPtr }]
-    basic_new_heap_raw basic_ptr
-    finalized_ptr <- newForeignPtr ptr_basic_free_heap_raw basic_ptr
+    basic_new_heap_ffi basic_ptr
+    finalized_ptr <- newForeignPtr ptr_basic_free_heap_ffi basic_ptr
     return $ BasicPtr { fptr = finalized_ptr }
 
 
 
-foreign import ccall "symengine/cwrapper.h ascii_art_str" ascii_art_str_raw :: IO CString
-foreign import ccall "symengine/cwrapper.h basic_new_heap" basic_new_heap_raw :: Ptr BasicStruct -> IO ()
-foreign import ccall "symengine/cwrapper.h &basic_free_heap" ptr_basic_free_heap_raw :: FunPtr(Ptr BasicStruct -> IO ())
-foreign import ccall "symengine/cwrapper.h basic_const_zero" basic_const_zero_raw :: Ptr BasicStruct -> IO ()
-foreign import ccall "symengine/cwrapper.h basic_str" basic_str_raw :: Ptr BasicStruct -> IO CString
+foreign import ccall "symengine/cwrapper.h ascii_art_str" ascii_art_str_ffi :: IO CString
+foreign import ccall "symengine/cwrapper.h basic_new_heap" basic_new_heap_ffi :: Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h &basic_free_heap" ptr_basic_free_heap_ffi :: FunPtr(Ptr BasicStruct -> IO ())
+foreign import ccall "symengine/cwrapper.h basic_const_zero" basic_const_zero_ffi :: Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_const_one" basic_const_one_ffi :: Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_const_minus_one" basic_const_minus_one_ffi :: Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_const_I" basic_const_I_ffi :: Ptr BasicStruct -> IO ()
+
+foreign import ccall "symengine/cwrapper.h basic_str" basic_str_ffi :: Ptr BasicStruct -> IO CString

--- a/src/Symengine.hs
+++ b/src/Symengine.hs
@@ -7,7 +7,6 @@ Description : Symengine bindings to Haskell
 module Symengine
     (
      ascii_art_str,
-     basic_str,
      zero,
      one,
      im,
@@ -43,6 +42,18 @@ instance Storable BasicStruct where
     poke basic_ptr BasicStruct{..} = pokeByteOff basic_ptr 0 data_ptr
 
 
+-- |represents a symbol exported by SymEngine. create this using the functions
+-- 'zero', 'one', 'minus_one', 'e', 'im', 'rational', 'complex', and also by
+-- constructing a number and converting it to a Symbol
+-- 
+-- >>> 3.5 :: BasicSym
+-- 7/2
+--
+-- >>> rational 2 10
+-- 1 /5
+--
+-- >>> complex 1 2
+-- 1 + 2*I
 data BasicSym = BasicSym { fptr :: ForeignPtr BasicStruct }
 
 withBasicSym :: BasicSym -> (Ptr BasicStruct -> IO a) -> IO a

--- a/src/Symengine.hs
+++ b/src/Symengine.hs
@@ -170,6 +170,10 @@ symbol name = unsafePerformIO $ do
     free cname
     return s
 
+-- |Differentiate an expression with respect to a symbol
+diff :: BasicSym -> BasicSym -> BasicSym
+diff expr symbol = (basic_binaryop basic_diff_ffi) expr symbol
+
 instance Show BasicSym where
     show = basic_str 
 
@@ -229,7 +233,7 @@ foreign import ccall "symengine/cwrapper.h basic_str" basic_str_ffi :: Ptr Basic
 foreign import ccall "symengine/cwrapper.h basic_eq" basic_eq_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO Int
 
 foreign import ccall "symengine/cwrapper.h symbol_set" symbol_set_ffi :: Ptr BasicStruct -> CString -> IO ()
-
+foreign import ccall "symengine/cwrapper.h basic_diff" basic_diff_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> Ptr BasicStruct -> IO ()
 
 foreign import ccall "symengine/cwrapper.h integer_set_si" integer_set_si_ffi :: Ptr BasicStruct -> CLong -> IO ()
 

--- a/src/Symengine.hs
+++ b/src/Symengine.hs
@@ -134,18 +134,6 @@ basic_unaryop f a = unsafePerformIO $ do
     return s 
 
 
-basic_add :: BasicSym -> BasicSym -> BasicSym
-basic_add = basic_binaryop basic_add_ffi
- 
-basic_sub :: BasicSym -> BasicSym -> BasicSym
-basic_sub = basic_binaryop basic_sub_ffi
-
-basic_mul :: BasicSym -> BasicSym -> BasicSym
-basic_mul = basic_binaryop basic_mul_ffi
-
-basic_div :: BasicSym -> BasicSym -> BasicSym
-basic_div = basic_binaryop basic_div_ffi
-
 basic_pow :: BasicSym -> BasicSym -> BasicSym
 basic_pow = basic_binaryop basic_pow_ffi
 
@@ -167,18 +155,38 @@ basic_rational_set_signed i j = unsafePerformIO $ do
 
 
 instance Num BasicSym where
-    (+) = basic_add
-    (-) = basic_sub
-    (*) = basic_mul
-    negate = basic_neg
-    abs = basic_abs
+    (+) = basic_binaryop basic_add_ffi
+    (-) = basic_binaryop basic_sub_ffi
+    (*) = basic_binaryop basic_mul_ffi
+    negate = basic_unaryop basic_neg_ffi
+    abs = basic_unaryop basic_abs_ffi
     signum = undefined
     fromInteger = basic_from_integer
 
 instance Fractional BasicSym where
-    (/) = basic_div
+    (/) = basic_binaryop basic_div_ffi
     fromRational (num :% denom) = basic_rational_set_signed num denom
     recip r = basic_const_one / r
+
+instance Floating BasicSym where
+    pi = basic_const_pi
+    --exp :: basic_binaryop basic_pow_ffi
+    log = undefined
+    sqrt x =  basic_pow x 0.5
+    (**) = basic_pow
+    logBase = undefined
+    sin = basic_unaryop basic_sin_ffi
+    cos = basic_unaryop basic_cos_ffi
+    tan = basic_unaryop basic_tan_ffi
+    asin = basic_unaryop basic_asin_ffi
+    acos = basic_unaryop basic_acos_ffi
+    atan = basic_unaryop basic_atan_ffi
+    sinh = basic_unaryop basic_sinh_ffi
+    cosh = basic_unaryop basic_cosh_ffi
+    tanh = basic_unaryop basic_tanh_ffi
+    asinh = basic_unaryop basic_asinh_ffi
+    acosh = basic_unaryop basic_acosh_ffi
+    atanh = basic_unaryop basic_atanh_ffi
 
 foreign import ccall "symengine/cwrapper.h ascii_art_str" ascii_art_str_ffi :: IO CString
 foreign import ccall "symengine/cwrapper.h basic_new_heap" basic_new_heap_ffi :: Ptr BasicStruct -> IO ()
@@ -206,3 +214,19 @@ foreign import ccall "symengine/cwrapper.h basic_div" basic_div_ffi :: Ptr Basic
 foreign import ccall "symengine/cwrapper.h basic_pow" basic_pow_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> Ptr BasicStruct -> IO ()
 foreign import ccall "symengine/cwrapper.h basic_neg" basic_neg_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO ()
 foreign import ccall "symengine/cwrapper.h basic_abs" basic_abs_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+
+foreign import ccall "symengine/cwrapper.h basic_sin" basic_sin_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_cos" basic_cos_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_tan" basic_tan_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+
+foreign import ccall "symengine/cwrapper.h basic_asin" basic_asin_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_acos" basic_acos_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_atan" basic_atan_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+
+foreign import ccall "symengine/cwrapper.h basic_sinh" basic_sinh_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_cosh" basic_cosh_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_tanh" basic_tanh_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+
+foreign import ccall "symengine/cwrapper.h basic_asinh" basic_asinh_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_acosh" basic_acosh_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_atanh" basic_atanh_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO ()

--- a/src/Symengine.hs
+++ b/src/Symengine.hs
@@ -49,6 +49,14 @@ basic_const_minus_one = basic_obj_constructor basic_const_minus_one_ffi
 basic_const_I :: IO BasicPtr
 basic_const_I = basic_obj_constructor basic_const_I_ffi
 
+basic_const_pi :: IO BasicPtr
+basic_const_pi = basic_obj_constructor basic_const_pi_ffi
+
+basic_const_E :: IO BasicPtr
+basic_const_E = basic_obj_constructor basic_const_E_ffi
+
+basic_const_EulerGamma :: IO BasicPtr
+basic_const_EulerGamma = basic_obj_constructor basic_const_EulerGamma_ffi
 
 basic_obj_constructor :: (Ptr BasicStruct -> IO ()) -> IO BasicPtr
 basic_obj_constructor init_fn = do
@@ -80,9 +88,16 @@ create_basic_ptr = do
 foreign import ccall "symengine/cwrapper.h ascii_art_str" ascii_art_str_ffi :: IO CString
 foreign import ccall "symengine/cwrapper.h basic_new_heap" basic_new_heap_ffi :: Ptr BasicStruct -> IO ()
 foreign import ccall "symengine/cwrapper.h &basic_free_heap" ptr_basic_free_heap_ffi :: FunPtr(Ptr BasicStruct -> IO ())
+
+-- constants
 foreign import ccall "symengine/cwrapper.h basic_const_zero" basic_const_zero_ffi :: Ptr BasicStruct -> IO ()
 foreign import ccall "symengine/cwrapper.h basic_const_one" basic_const_one_ffi :: Ptr BasicStruct -> IO ()
 foreign import ccall "symengine/cwrapper.h basic_const_minus_one" basic_const_minus_one_ffi :: Ptr BasicStruct -> IO ()
 foreign import ccall "symengine/cwrapper.h basic_const_I" basic_const_I_ffi :: Ptr BasicStruct -> IO ()
-
+foreign import ccall "symengine/cwrapper.h basic_const_pi" basic_const_pi_ffi :: Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_const_E" basic_const_E_ffi :: Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_const_EulerGamma" basic_const_EulerGamma_ffi :: Ptr BasicStruct -> IO ()
 foreign import ccall "symengine/cwrapper.h basic_str" basic_str_ffi :: Ptr BasicStruct -> IO CString
+
+--operations
+foreign import ccall "symengine/cwrapper.h basic_add" basic_add_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> Ptr BasicStruct -> IO ()

--- a/src/Symengine.hs
+++ b/src/Symengine.hs
@@ -14,7 +14,7 @@ module Symengine
      basic_const_pi,
      basic_const_EulerGamma,
      basic_const_minus_one,
-     basic_int_signed,
+     basic_rational,
      BasicSym,
     ) where
 
@@ -137,17 +137,11 @@ basic_unaryop f a = unsafePerformIO $ do
 basic_pow :: BasicSym -> BasicSym -> BasicSym
 basic_pow = basic_binaryop basic_pow_ffi
 
-basic_neg :: BasicSym -> BasicSym
-basic_neg = basic_unaryop basic_neg_ffi
+basic_rational :: BasicSym -> BasicSym -> BasicSym
+basic_rational = basic_binaryop rational_set_ffi
 
-basic_abs :: BasicSym -> BasicSym
-basic_abs = basic_unaryop basic_abs_ffi
-
-basic_rational_set :: BasicSym -> BasicSym -> BasicSym
-basic_rational_set = basic_binaryop rational_set_ffi
-
-basic_rational_set_signed :: Integer -> Integer -> BasicSym
-basic_rational_set_signed i j = unsafePerformIO $ do
+basic_rational_from_integer :: Integer -> Integer -> BasicSym
+basic_rational_from_integer i j = unsafePerformIO $ do
     s <- create_basic_ptr
     withBasicSym s (\s -> rational_set_si_ffi s (integerToCLong i) (integerToCLong j))
     return s 
@@ -165,7 +159,7 @@ instance Num BasicSym where
 
 instance Fractional BasicSym where
     (/) = basic_binaryop basic_div_ffi
-    fromRational (num :% denom) = basic_rational_set_signed num denom
+    fromRational (num :% denom) = basic_rational_from_integer num denom
     recip r = basic_const_one / r
 
 instance Floating BasicSym where

--- a/src/Symengine.hs
+++ b/src/Symengine.hs
@@ -6,7 +6,11 @@ module Symengine
      basic_str,
      basic_const_zero,
      basic_const_one,
+     basic_const_I,
+     basic_const_pi,
+     basic_const_EulerGamma,
      basic_const_minus_one,
+     basic_int_signed,
      BasicPtr,
     ) where
 
@@ -18,7 +22,8 @@ import Foreign.Marshal.Array
 import Foreign.ForeignPtr
 import Control.Applicative
 import System.IO.Unsafe
-
+import Control.Monad
+import GHC.Real
 
 data BasicStruct = BasicStruct {
     data_ptr :: Ptr ()
@@ -32,40 +37,69 @@ instance Storable BasicStruct where
 
 data BasicPtr = BasicPtr { fptr :: ForeignPtr BasicStruct }
 
+withBasicPtr :: BasicPtr -> (Ptr BasicStruct -> IO a) -> IO a
+withBasicPtr p f = withForeignPtr (fptr p ) f
+
+withBasicPtr2 :: BasicPtr -> BasicPtr -> (Ptr BasicStruct -> Ptr BasicStruct -> IO a) -> IO a
+withBasicPtr2 p1 p2 f = withBasicPtr p1 (\p1 -> withBasicPtr p2 (\p2 -> f p1 p2))
+
+withBasicPtr3 :: BasicPtr -> BasicPtr -> BasicPtr -> (Ptr BasicStruct -> Ptr BasicStruct -> Ptr BasicStruct -> IO a) -> IO a
+withBasicPtr3 p1 p2 p3 f = withBasicPtr p1 (\p1 -> withBasicPtr p2 (\p2 -> withBasicPtr p3 (\p3 -> f p1 p2 p3)))
+
 instance Show BasicPtr where
     show = basic_str 
 
 
-basic_const_zero :: IO BasicPtr
+basic_const_zero :: BasicPtr
 basic_const_zero = basic_obj_constructor basic_const_zero_ffi
 
 
-basic_const_one :: IO BasicPtr
+basic_const_one :: BasicPtr
 basic_const_one = basic_obj_constructor basic_const_one_ffi
 
-basic_const_minus_one :: IO BasicPtr
+basic_const_minus_one :: BasicPtr
 basic_const_minus_one = basic_obj_constructor basic_const_minus_one_ffi
 
-basic_const_I :: IO BasicPtr
+basic_const_I :: BasicPtr
 basic_const_I = basic_obj_constructor basic_const_I_ffi
 
-basic_const_pi :: IO BasicPtr
+basic_const_pi :: BasicPtr
 basic_const_pi = basic_obj_constructor basic_const_pi_ffi
 
-basic_const_E :: IO BasicPtr
+basic_const_E :: BasicPtr
 basic_const_E = basic_obj_constructor basic_const_E_ffi
 
-basic_const_EulerGamma :: IO BasicPtr
+basic_const_EulerGamma :: BasicPtr
 basic_const_EulerGamma = basic_obj_constructor basic_const_EulerGamma_ffi
 
-basic_obj_constructor :: (Ptr BasicStruct -> IO ()) -> IO BasicPtr
-basic_obj_constructor init_fn = do
+basic_obj_constructor :: (Ptr BasicStruct -> IO ()) -> BasicPtr
+basic_obj_constructor init_fn = unsafePerformIO $ do
     basic_ptr <- create_basic_ptr
-    withForeignPtr (fptr basic_ptr) init_fn
-    return $ basic_ptr
+    withBasicPtr basic_ptr init_fn
+    return basic_ptr
 
 basic_str :: BasicPtr -> String
-basic_str basic_ptr = unsafePerformIO $ withForeignPtr (fptr basic_ptr) (\p -> basic_str_ffi p >>= peekCString)
+basic_str basic_ptr = unsafePerformIO $ withBasicPtr basic_ptr (basic_str_ffi >=> peekCString)
+
+integerToCLong :: Integer -> CLong
+integerToCLong i = CLong (fromInteger i)
+
+
+intToCLong :: Int -> CLong
+intToCLong i = integerToCLong (toInteger i)
+
+basic_int_signed :: Int -> BasicPtr
+basic_int_signed i = unsafePerformIO $ do
+    iptr <- create_basic_ptr
+    withBasicPtr iptr (\iptr -> integer_set_si_ffi iptr (intToCLong i) )
+    return iptr
+
+
+basic_from_integer :: Integer -> BasicPtr
+basic_from_integer i = unsafePerformIO $ do
+    iptr <- create_basic_ptr
+    withBasicPtr iptr (\iptr -> integer_set_si_ffi iptr (fromInteger i))
+    return iptr
 
 -- |The `ascii_art_str` function prints SymEngine in ASCII art.
 -- this is useful as a sanity check
@@ -83,7 +117,64 @@ create_basic_ptr = do
     finalized_ptr <- newForeignPtr ptr_basic_free_heap_ffi basic_ptr
     return $ BasicPtr { fptr = finalized_ptr }
 
+basic_binaryop :: (Ptr BasicStruct -> Ptr BasicStruct -> Ptr BasicStruct -> IO ()) -> BasicPtr -> BasicPtr -> BasicPtr
+basic_binaryop f a b = unsafePerformIO $ do
+    s <- create_basic_ptr
+    withBasicPtr3 s a b f
+    return s 
 
+basic_unaryop :: (Ptr BasicStruct -> Ptr BasicStruct -> IO ()) -> BasicPtr -> BasicPtr
+basic_unaryop f a = unsafePerformIO $ do
+    s <- create_basic_ptr
+    withBasicPtr2 s a f
+    return s 
+
+
+basic_add :: BasicPtr -> BasicPtr -> BasicPtr
+basic_add = basic_binaryop basic_add_ffi
+ 
+basic_sub :: BasicPtr -> BasicPtr -> BasicPtr
+basic_sub = basic_binaryop basic_sub_ffi
+
+basic_mul :: BasicPtr -> BasicPtr -> BasicPtr
+basic_mul = basic_binaryop basic_mul_ffi
+
+basic_div :: BasicPtr -> BasicPtr -> BasicPtr
+basic_div = basic_binaryop basic_div_ffi
+
+basic_pow :: BasicPtr -> BasicPtr -> BasicPtr
+basic_pow = basic_binaryop basic_pow_ffi
+
+basic_neg :: BasicPtr -> BasicPtr
+basic_neg = basic_unaryop basic_neg_ffi
+
+basic_abs :: BasicPtr -> BasicPtr
+basic_abs = basic_unaryop basic_abs_ffi
+
+basic_rational_set :: BasicPtr -> BasicPtr -> BasicPtr
+basic_rational_set = basic_binaryop rational_set_ffi
+
+basic_rational_set_signed :: Integer -> Integer -> BasicPtr
+basic_rational_set_signed i j = unsafePerformIO $ do
+    s <- create_basic_ptr
+    withBasicPtr s (\s -> rational_set_si_ffi s (integerToCLong i) (integerToCLong j))
+    return s 
+
+
+
+instance Num BasicPtr where
+    (+) = basic_add
+    (-) = basic_sub
+    (*) = basic_mul
+    negate = basic_neg
+    abs = basic_abs
+    signum = undefined
+    fromInteger = basic_from_integer
+
+instance Fractional BasicPtr where
+    (/) = basic_div
+    fromRational (num :% denom) = basic_rational_set_signed num denom
+    recip r = basic_const_one / r
 
 foreign import ccall "symengine/cwrapper.h ascii_art_str" ascii_art_str_ffi :: IO CString
 foreign import ccall "symengine/cwrapper.h basic_new_heap" basic_new_heap_ffi :: Ptr BasicStruct -> IO ()
@@ -99,5 +190,17 @@ foreign import ccall "symengine/cwrapper.h basic_const_E" basic_const_E_ffi :: P
 foreign import ccall "symengine/cwrapper.h basic_const_EulerGamma" basic_const_EulerGamma_ffi :: Ptr BasicStruct -> IO ()
 foreign import ccall "symengine/cwrapper.h basic_str" basic_str_ffi :: Ptr BasicStruct -> IO CString
 
---operations
+foreign import ccall "symengine/cwrapper.h integer_set_si" integer_set_si_ffi :: Ptr BasicStruct -> CLong -> IO ()
+
+foreign import ccall "symengine/cwrapper.h rational_set" rational_set_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h rational_set_si" rational_set_si_ffi :: Ptr BasicStruct -> CLong -> CLong -> IO ()
+
 foreign import ccall "symengine/cwrapper.h basic_add" basic_add_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_sub" basic_sub_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_mul" basic_mul_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_div" basic_div_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_pow" basic_pow_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_neg" basic_neg_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+foreign import ccall "symengine/cwrapper.h basic_abs" basic_abs_ffi :: Ptr BasicStruct -> Ptr BasicStruct -> IO ()
+
+

--- a/src/Symengine.hs
+++ b/src/Symengine.hs
@@ -212,7 +212,7 @@ instance Floating BasicSym where
     pi = Symengine.pi
     exp x = e ** x
     log = undefined
-    sqrt x = x  ** 0.5
+    sqrt x = x  ** 1/2
     (**) = basic_pow
     logBase = undefined
     sin = basic_unaryop basic_sin_ffi

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -7,6 +7,7 @@ import Data.Ord
 import Data.Monoid
 
 import Symengine as Sym
+import Prelude hiding (pi)
 
 main = defaultMain tests
 
@@ -29,10 +30,24 @@ unitTests = testGroup "Unit tests"
 
     , HU.testCase "Basic Constructors" $
     do
-      let zero = basic_const_zero
-      let one = basic_const_one
-      let minus_one = basic_const_minus_one
       "0" @?= (show zero)     
       "1" @?= (show one)     
-      "-1" @?= (show minus_one)     
+      "-1" @?= (show minus_one)
+    , HU.testCase "Basic Trignometric Functions" $
+    do
+      let pi_over_3 = pi / 3 :: BasicSym
+      let pi_over_2 = pi / 2 :: BasicSym
+
+      sin zero @?= zero
+      cos zero @?= one
+      
+      sin (pi / 6) @?= 1 / 2
+      sin (pi / 3) @?= 3 ** 0.5 / 2
+
+      cos (pi / 6) @?= 3 ** 0.5 / 2
+      cos (pi / 3) @?= 1 / 2 
+
+      sin pi_over_2 @?= one
+      cos pi_over_2 @?= zero
+
   ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -42,9 +42,9 @@ unitTests = testGroup "Unit tests"
       cos zero @?= one
       
       sin (pi / 6) @?= 1 / 2
-      sin (pi / 3) @?= 3 ** 0.5 / 2
+      sin (pi / 3) @?= (3 ** (1/2)) / 2
 
-      cos (pi / 6) @?= 3 ** 0.5 / 2
+      cos (pi / 6) @?= (3 ** (1/2)) / 2
       cos (pi / 3) @?= 1 / 2 
 
       sin pi_over_2 @?= one

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -23,5 +23,7 @@ unitTests = testGroup "Unit tests"
   [ HU.testCase "FFI Sanity Check - ASCII Art should be non-empty" $ 
     do
       ascii_art <- Sym.ascii_art_str
+      zero <- basic_const_zero
+      print $ show zero
       HU.assertBool "ASCII art from ascii_art_str is empty" (not . null $ ascii_art)
   ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -4,6 +4,7 @@ import Test.Tasty.HUnit as HU
 
 import Data.List
 import Data.Ord
+import Data.Monoid
 
 import Symengine as Sym
 
@@ -19,11 +20,19 @@ tests = testGroup "Tests" [unitTests]
 -- properties :: TestTree
 -- properties = testGroup "Properties" [qcProps]
 
-unitTests = testGroup "Unit tests"
-  [ HU.testCase "FFI Sanity Check - ASCII Art should be non-empty" $ 
+unitTests = testGroup "FFI Sanity Checks"
+  [ HU.testCase "ASCII Art should be non-empty" $ 
     do
       ascii_art <- Sym.ascii_art_str
-      zero <- basic_const_zero
-      print $ show zero
       HU.assertBool "ASCII art from ascii_art_str is empty" (not . null $ ascii_art)
+
+
+    , HU.testCase "Basic Constructors" $
+    do
+      zero <- basic_const_zero
+      one <- basic_const_one
+      minus_one <- basic_const_minus_one
+      "0" @?= (show 0)     
+      "1" @?= (show one)     
+      "-1" @?= (show minus_one)     
   ]


### PR DESCRIPTION
Currently, numeric tower works - so `+`, `-`, `/`, `*`, `**` all work.

You can create a symbolic integer by constructing it as one. This will be constructed as a `BasicSym` because it has implemented the `fromInteger` method of the `Num` typeclass. For example, something like this:

```
*Symengine Symengine> let x = -3 :: BasicSym
*Symengine Symengine> x
-3
```

A similar construction works for `float` as well, like so:

```
*Symengine Symengine> let y = 3.5 :: BasicSym
*Symengine Symengine> y
7/2
```

Rationals can also be constructed by using the `rational` function in `Symengine` by passing a numerator and a denominator

```
*Symengine Symengine> rational 2 10
1/5
*Symengine Symengine> let x = rational 1 10
*Symengine Symengine> let y = rational 2 10
*Symengine Symengine> x + y
3/10
*Symengine Symengine> x - y
-1/10
*Symengine Symengine> x * y
1/50
*Symengine Symengine> x / y
1/2
```

complex numbers can be constructed by either calling the `complex` function with a real and imaginary part, or by manually constructing them with the `im` value exported by `Symengine`

```
*Symengine Symengine> let x = complex 1 2
*Symengine Symengine> let y = complex 3 4
*Symengine Symengine> x
1 + 2*I
*Symengine Symengine> y
3 + 4*I
*Symengine Symengine> x + y
4 + 6*I
*Symengine Symengine> x - y
-2 - 2*I
*Symengine Symengine> x * y
-5 + 10*I
*Symengine Symengine> let z = 10 + 20 * im
*Symengine Symengine> z
10 + 20*I
```

Differentiation and symbolics work by first creating a symbol through the `symbol` function. You can then use it just like you would use a SymPy symbol. Differentiation works by calling the `diff` function with an expression and the symbol to differentiate by.

```
*Symengine Symengine> let x = symbol "x"
*Symengine Symengine> x
x
*Symengine Symengine> let y = sin(x)
*Symengine Symengine> y
sin(x)
*Symengine Symengine> diff y x
cos(x)
*Symengine Symengine> let z = symbol "z"
*Symengine Symengine> let y = sin(x * z)
*Symengine Symengine> y
sin(x*z)
*Symengine Symengine> diff y x
z*cos(x*z)
*Symengine Symengine> diff y z
x*cos(x*z)
```

There's stuff like `log` and `logBase` that I've left undefined because I couldn't find the definitions. I guess I'll have to work on the wrappers and bind these.

Next stop: Polynomials and matrices.
