### PR TITLE
Don't add random system-dependent directories into the search path

### DIFF
--- a/symengine.cabal
+++ b/symengine.cabal
@@ -29,7 +29,6 @@ test-suite symengine-test
                      , tasty-hunit >= 0.9.0 && <= 1.5
                      , tasty-quickcheck >= 0.8.0 && <= 1.5
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
-  include-dirs:        /usr/local/include/
   extra-libraries:     symengine stdc++ gmpxx gmp
   
   other-modules:       Symengine


### PR DESCRIPTION
It's better to let the *user* control the search path when calling `cabal configure`. Adding paths like `/usr/local/include` may actually break a build that would otherwise succeed.